### PR TITLE
feature: Check for automatic lock screen in Sway DE

### DIFF
--- a/checks/lockscreen_timeout_activated_sway/sway_has_screenlock_timeout_activated.sql
+++ b/checks/lockscreen_timeout_activated_sway/sway_has_screenlock_timeout_activated.sql
@@ -1,0 +1,11 @@
+SELECT
+  CAST(regex_match(cmdline, 'timeout (\d+) swaylock)', 1) as INTEGER) as swaylock_timeout_seconds_regex_match,
+  regex_match(cmdline, 'before-sleep swaylock', 0) as swaylock_before_sleep_regex_match
+FROM
+  processes
+WHERE (
+  name = 'swayidle'
+AND
+  swaylock_timeout_seconds_regex_match <= 600
+  and swaylock_before_sleep_regex_match = 'before-sleep swaylock'
+);

--- a/checks/lockscreen_timeout_activated_sway/user-feedback-text.md
+++ b/checks/lockscreen_timeout_activated_sway/user-feedback-text.md
@@ -1,0 +1,30 @@
+# Failing Check: Lockscreen timeout not configured for Sway Desktop Environment
+Reason: Unable to find acceptable timeout for `swaylock` in `swayidle`'s running process' command line.
+
+## Why is this a problem?
+naisdevice policy ([Do's & Don'ts](https://naisdevice-approval.nais.io/)) requires an automatic screen lock timeout be activated to hinder unwarranted access to your nais device.
+This needs to be activated and active at any given time, so that it's not forgotten the hypothetically _one_ time you work at a Café and forget to lock the PC.
+
+## Required Action
+1. Ensure `swayidle` is executed at login into Sway, with a timeout of maximum 10 minutes.
+
+### Example configuration
+`~/.config/sway/config`:
+```
+(...)
+### Idle configuration
+set $swaylock swaylock --config ~/.config/sway/swaylock.conf
+exec swayidle -w \
+        timeout 15 'pgrep --exact swaylock && swaymsg "output * dpms off"' \
+                resume 'swaymsg "output * dpms on"' \
+        timeout 660 'swaymsg "output * dpms off"' \
+                resume 'swaymsg "output * dpms on"' \
+        timeout 600 "$swaylock" \
+        before-sleep "$swaylock" \
+        after-resume 'swaymsg "output * dpms on"'
+# This will lock your screen after 600 seconds of inactivity, then turn off your displays after another 60 seconds, and turn your screens back on when resumed.
+# It will also lock your screen before your computer goes to sleep.
+#
+# If your computer is idle for 15 seconds and a 'swaylock' process is running, the screen is turned off.
+(...)
+```


### PR DESCRIPTION
@toby1knby: Skal vi droppe å sjekke etter tiden det tar før låsen inntreffer?
Er det nok å bare sjekke om `swaylock` kommandoen eksisterer et eller annet sted i `swayidle` sin kommando?

Hvis vi skal sjekke tiden, er 10 min korrekt tid å sjekke som maksimum?