### PR TITLE
Ensure limited readability&writeability for files within `/var/log/**`

### DIFF
--- a/checks/ensure_safe_logfiles_permissions/README.md
+++ b/checks/ensure_safe_logfiles_permissions/README.md
@@ -1,0 +1,2 @@
+To test:
+`osqueryi < ensure_safe_logfiles_permissions.sql`

--- a/checks/ensure_safe_logfiles_permissions/ensure_safe_logfiles_permissions.sql
+++ b/checks/ensure_safe_logfiles_permissions/ensure_safe_logfiles_permissions.sql
@@ -1,0 +1,18 @@
+SELECT
+	--f.path,
+	--u.username AS file_owner,
+	--g.groupname AS group_owner,
+	f.mode AS permission_bits,
+	COUNT(*)
+FROM file f
+	LEFT JOIN users u ON f.uid == u.uid
+	LEFT JOIN groups g ON f.gid == g.gid
+WHERE
+	f.type == 'regular'
+AND
+	f.path LIKE '/var/log/%%'
+AND NOT (
+	permission_bits == '0640'
+	OR permission_bits == '0600'
+) GROUP BY
+	permission_bits;


### PR DESCRIPTION
Rationale:  Only owner of file should be able to read/write, and only group should be able to read. All else should be zero/not permitted.

Group may also be disallowed to read (e.g. octal bit `0`)